### PR TITLE
Talk description now has links (http/https) made into actual links.

### DIFF
--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -238,4 +238,8 @@ class Talk < ApplicationRecord
     "\"#{self.title}\" by #{self.speaker_name}"
   end
 
+  def description_with_links
+    self.description.gsub(URI.regexp(['http', 'https']), '<a href="\0">\0</a>')
+  end
+
 end

--- a/app/views/talks/show.html.erb
+++ b/app/views/talks/show.html.erb
@@ -63,7 +63,7 @@
 
   <div class="description">
     <% if contains_html @talk.description %>
-        <%= sanitize @talk.description %>
+        <%= sanitize @talk.description_with_links %>
     <% else %>
         <%= simple_format h(@talk.description) %>
     <% end %>


### PR DESCRIPTION
Only works with http/https-links.